### PR TITLE
右メニューの課題の科目名、課題をクリックしたときに課題ページに飛ぶようにする

### DIFF
--- a/public/css/comfortable-sakai.css
+++ b/public/css/comfortable-sakai.css
@@ -407,7 +407,7 @@
     background: none;
     border: none;
     padding: 0;
-    font-size: 13px;
+    font: inherit;
     color: var(--textColor) !important; /* リンクのデフォルトの色を打ち消す */
     text-decoration: underline;
     cursor: pointer;

--- a/public/css/comfortable-sakai.css
+++ b/public/css/comfortable-sakai.css
@@ -408,7 +408,7 @@
     border: none;
     padding: 0;
     font-size: 13px;
-    color: var(--textColor);
+    color: var(--textColor) !important; /* リンクのデフォルトの色を打ち消す */
     text-decoration: underline;
     cursor: pointer;
     word-break: break-word;

--- a/public/css/comfortable-sakai.css
+++ b/public/css/comfortable-sakai.css
@@ -403,6 +403,17 @@
     word-break: break-word;
 }
 
+.cs-assignment-title-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font-size: 13px;
+    color: var(--textColor);
+    text-decoration: underline;
+    cursor: pointer;
+    word-break: break-word;
+}
+
 .cs-minisakai-btn-div {
     /* buttonのデフォルトスタイルを打ち消す */
     background-color: transparent !important;

--- a/src/components/assignment.tsx
+++ b/src/components/assignment.tsx
@@ -46,7 +46,7 @@ export default function AssignmentEntryView(props: {
                         <button
                             type="button"
                             className="cs-assignment-title-link"
-                            onClick={() => chrome.tabs.create({ url: props.entryURL!, active: true })}
+                            onClick={() => chrome.tabs.create({ url: props.entryURL, active: true })}
                         >
                             {props.assignment.title}
                         </button>

--- a/src/components/assignment.tsx
+++ b/src/components/assignment.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "./helper";
 export default function AssignmentEntryView(props: {
     assignment: AssignmentEntry;
     isSubset: boolean;
+    entryURL?: string;
     onCheck: (checked: boolean) => void;
 }) {
     const dueTime = props.assignment.isDuePassed(CurrentTime) ? props.assignment.closeTime : props.assignment.dueTime;
@@ -40,7 +41,23 @@ export default function AssignmentEntryView(props: {
                 {props.assignment.isDuePassed(CurrentTime) && (
                     <span className="cs-badge cs-badge-late">{lateBadge}</span>
                 )}
-                {props.assignment.title}
+                {props.entryURL ? (
+                    props.isSubset ? (
+                        <button
+                            type="button"
+                            className="cs-assignment-title-link"
+                            onClick={() => chrome.tabs.create({ url: props.entryURL!, active: true })}
+                        >
+                            {props.assignment.title}
+                        </button>
+                    ) : (
+                        <a href={props.entryURL} className="cs-assignment-title-link">
+                            {props.assignment.title}
+                        </a>
+                    )
+                ) : (
+                    props.assignment.title
+                )}
             </p>
         </>
     );

--- a/src/components/entryTab.tsx
+++ b/src/components/entryTab.tsx
@@ -32,15 +32,33 @@ function MiniSakaiCourse(props: {
     const divClass = useMemo(() => `cs-assignment-${props.dueType}`, [props.dueType]);
     const aClass = useMemo(() => `cs-course-${props.dueType} cs-course-name`, [props.dueType]);
 
+    const toolPlacementId = useMemo(() => {
+        const match = props.coursePage.match(/\/(?:page|tool-reset)\/([^/?#]+)/);
+        return match ? match[1] : null;
+    }, [props.coursePage]);
+
+    const toolResetURL = useMemo(() => {
+        if (!toolPlacementId) return props.coursePage;
+        return props.coursePage.replace(/\/(?:page|tool-reset)\/[^/?#]+/, `/tool-reset/${toolPlacementId}`);
+    }, [props.coursePage, toolPlacementId]);
+
+    const courseOrigin = useMemo(() => {
+        try { return new URL(props.coursePage).origin; } catch { return ""; }
+    }, [props.coursePage]);
+
     const elements = useMemo(() => {
         const elems: JSX.Element[] = [];
         for (const entry of props.entries) {
             if (entry instanceof AssignmentEntry) {
+                const entryURL = toolPlacementId
+                    ? `${courseOrigin}/portal/site/${props.courseID}/tool/${toolPlacementId}?assignmentReference=/assignment/a/${props.courseID}/${entry.id}&sakai_action=doView_submission`
+                    : undefined;
                 elems.push(
                     <AssignmentEntryView
                         key={entry.getID()}
                         isSubset={props.isSubset}
                         assignment={entry}
+                        entryURL={entryURL}
                         onCheck={(checked) => props.onCheck(entry, checked)}
                     />
                 );
@@ -66,7 +84,7 @@ function MiniSakaiCourse(props: {
             }
         }
         return elems;
-    }, [props]);
+    }, [props, toolPlacementId, courseOrigin]);
 
     return (
         // TODO: style
@@ -75,12 +93,12 @@ function MiniSakaiCourse(props: {
             {props.isSubset ? (
                 <button className={`${aClass} course-button`} onClick={() => {
                     chrome.tabs.create({
-                        url: props.coursePage,
+                        url: toolResetURL,
                         active: true
                     })
                 }}>{props.courseName}</button>
             ) : (
-                <a className={aClass} href={props.coursePage}>
+                <a className={aClass} href={toolResetURL}>
                     {props.courseName}
                 </a>
             )}
@@ -398,15 +416,20 @@ function MiniSakaiEntryList(props: {
     const courses: JSX.Element[] = [];
     for (const [courseID, entries] of courseIdMap.entries()) {
         const courseName = courseNameMap.get(courseID) ?? "<unknown>";
+        const sortedEntries = entries.sort(sortEntries);
+        const hostname = props.settings.appInfo.hostname;
+        const firstAssignment = sortedEntries.find(e => e instanceof AssignmentEntry) as AssignmentEntry | undefined;
+        const coursePage = firstAssignment?.assignmentPageURL
+            ?? `https://${hostname}/portal/site/${courseID}`;
         courses.push(
             <MiniSakaiCourse
                 key={courseID}
                 courseID={courseID}
                 courseName={courseName}
-                coursePage={"https://" + props.settings.appInfo.hostname + "/portal/site/" + courseID}
+                coursePage={coursePage}
                 isSubset={props.isSubset}
                 dueType={props.dueType}
-                entries={entries.sort(sortEntries)}
+                entries={sortedEntries}
                 onCheck={(entry, checked) => props.onCheck(entry, checked)}
                 onDelete={(entry) => props.onDelete(entry)}
             />

--- a/src/components/entryTab.tsx
+++ b/src/components/entryTab.tsx
@@ -51,7 +51,14 @@ function MiniSakaiCourse(props: {
         for (const entry of props.entries) {
             if (entry instanceof AssignmentEntry) {
                 const entryURL = toolPlacementId
-                    ? `${courseOrigin}/portal/site/${props.courseID}/tool/${toolPlacementId}?assignmentReference=/assignment/a/${props.courseID}/${entry.id}&sakai_action=doView_submission`
+                    ? (() => {
+                        const url = new URL(
+                            `${courseOrigin}/portal/site/${props.courseID}/tool/${toolPlacementId}`
+                        );
+                        url.searchParams.set("assignmentReference", `/assignment/a/${props.courseID}/${entry.id}`);
+                        url.searchParams.set("sakai_action", "doView_submission");
+                        return url.toString();
+                    })()
                     : undefined;
                 elems.push(
                     <AssignmentEntryView
@@ -418,7 +425,9 @@ function MiniSakaiEntryList(props: {
         const courseName = courseNameMap.get(courseID) ?? "<unknown>";
         const sortedEntries = entries.sort(sortEntries);
         const hostname = props.settings.appInfo.hostname;
-        const firstAssignment = sortedEntries.find(e => e instanceof AssignmentEntry) as AssignmentEntry | undefined;
+        const firstAssignment = sortedEntries.find(
+            (e): e is AssignmentEntry => e instanceof AssignmentEntry
+        );
         const coursePage = firstAssignment?.assignmentPageURL
             ?? `https://${hostname}/portal/site/${courseID}`;
         courses.push(

--- a/src/features/api/fetch.ts
+++ b/src/features/api/fetch.ts
@@ -35,6 +35,40 @@ export const fetchCourse = (): Array<Course> => {
     return courses;
 };
 
+/* page/[pageId] URL にリクエストして 302 リダイレクト先から tool placement ID を取得する */
+const fetchToolPlacementURL = async (pageURL: string): Promise<string | null> => {
+    try {
+        const response = await fetch(pageURL, { cache: "no-cache" });
+        const finalURL = response.url;
+        response.body?.cancel();
+        const match = finalURL.match(/\/tool(?:-reset)?\/([^/?#]+)/);
+        if (!match) return null;
+        const toolPlacementId = match[1];
+        return finalURL.replace(/\/tool(?:-reset)?\/[^/?#]+.*$/, `/tool-reset/${toolPlacementId}`);
+    } catch {
+        return null;
+    }
+};
+
+/* /direct/site/[siteId].json の sitePages から「課題」ページの tool-reset URL を取得する */
+const fetchAssignmentPageURL = async (siteId: string): Promise<string | null> => {
+    const queryURL = getBaseURL() + "/direct/site/" + siteId + ".json";
+    try {
+        const response = await fetch(queryURL, { cache: "no-cache" });
+        if (!response.ok) return null;
+        const data = await response.json();
+        const pages: any[] = data.sitePages ?? [];
+        for (const page of pages) {
+            if (page.title === "課題" && page.url) {
+                return await fetchToolPlacementURL(page.url);
+            }
+        }
+        return null;
+    } catch {
+        return null;
+    }
+};
+
 /* Sakai APIから課題を取得する */
 export const fetchAssignment = (course: Course): Promise<Assignment> => {
     const queryURL = getBaseURL() + "/direct/assignment/site/" + course.id + ".json";
@@ -44,6 +78,10 @@ export const fetchAssignment = (course: Course): Promise<Assignment> => {
                 if (response.ok) {
                     const data = await response.json();
                     const assignmentEntries = decodeAssignmentFromAPI(data);
+                    const assignmentPageURL = await fetchAssignmentPageURL(course.id);
+                    if (assignmentPageURL) {
+                        assignmentEntries.forEach(e => { e.assignmentPageURL = assignmentPageURL; });
+                    }
                     resolve(new Assignment(course, assignmentEntries, false));
                 } else {
                     reject(`Request failed: ${response.status}`);

--- a/src/features/api/fetch.ts
+++ b/src/features/api/fetch.ts
@@ -51,8 +51,14 @@ const fetchToolPlacementURL = async (pageURL: string): Promise<string | null> =>
     }
 };
 
+/* course.id ごとに解決済み assignment page URL をキャッシュする */
+const assignmentPageURLCache = new Map<string, string>();
+
 /* /direct/site/[siteId].json の sitePages から「課題」ページの tool-reset URL を取得する */
 const fetchAssignmentPageURL = async (siteId: string): Promise<string | null> => {
+    const cached = assignmentPageURLCache.get(siteId);
+    if (cached !== undefined) return cached;
+
     const queryURL = getBaseURL() + "/direct/site/" + siteId + ".json";
     try {
         const response = await fetch(queryURL, { cache: "no-cache" });
@@ -61,7 +67,9 @@ const fetchAssignmentPageURL = async (siteId: string): Promise<string | null> =>
         const pages: any[] = data.sitePages ?? [];
         for (const page of pages) {
             if (page.title === "課題" && page.url) {
-                return await fetchToolPlacementURL(page.url);
+                const url = await fetchToolPlacementURL(page.url);
+                if (url) assignmentPageURLCache.set(siteId, url);
+                return url;
             }
         }
         return null;

--- a/src/features/api/fetch.ts
+++ b/src/features/api/fetch.ts
@@ -45,7 +45,8 @@ const fetchToolPlacementURL = async (pageURL: string): Promise<string | null> =>
         if (!match) return null;
         const toolPlacementId = match[1];
         return finalURL.replace(/\/tool(?:-reset)?\/[^/?#]+.*$/, `/tool-reset/${toolPlacementId}`);
-    } catch {
+    } catch (err) {
+        console.error(err);
         return null;
     }
 };
@@ -64,7 +65,8 @@ const fetchAssignmentPageURL = async (siteId: string): Promise<string | null> =>
             }
         }
         return null;
-    } catch {
+    } catch (err) {
+        console.error(err);
         return null;
     }
 };

--- a/src/features/entity/assignment/decode.ts
+++ b/src/features/entity/assignment/decode.ts
@@ -12,7 +12,8 @@ export const decodeAssignmentFromAPI = (data: Record<string, any>): Array<Assign
                 json.title,
                 json.dueTime.epochSecond ? json.dueTime.epochSecond : null,
                 json.closeTime.epochSecond ? json.closeTime.epochSecond : null,
-                false
+                false,
+                json.entityURL
             );
             return entry;
         });
@@ -26,7 +27,7 @@ export const decodeAssignmentFromArray = (data: Array<any>): Array<Assignment> =
         const isRead: boolean = assignment.isRead;
         const entries: Array<AssignmentEntry> = [];
         for (const e of assignment.entries) {
-            const entry = new AssignmentEntry(e.id, e.title, e.dueTime, e.closeTime, e.hasFinished);
+            const entry = new AssignmentEntry(e.id, e.title, e.dueTime, e.closeTime, e.hasFinished, e.entityURL, e.assignmentPageURL);
             if (entry.getCloseDateTimestamp > CurrentTime) entries.push(entry);
         }
         assignments.push(new Assignment(course, entries, isRead));

--- a/src/features/entity/assignment/types.ts
+++ b/src/features/entity/assignment/types.ts
@@ -8,7 +8,9 @@ export class AssignmentEntry implements EntryProtocol {
         public title: string,
         public dueTime: number,
         public closeTime: number,
-        public hasFinished: boolean
+        public hasFinished: boolean,
+        public entityURL?: string,
+        public assignmentPageURL?: string
     ) {}
 
     getTimestamp(currentTime: number, showLateAcceptedEntry: boolean): number {


### PR DESCRIPTION
## Description

右メニューの課題一覧で、科目名と各課題タイトルをクリック可能にした。

- **科目名クリック** → 課題一覧ページ（`tool-reset/[toolPlacementId]`）へ遷移
- **課題タイトルクリック** → 課題詳細・提出ページ（`tool/[toolPlacementId]?assignmentReference=...`）へ遷移

tool placement ID は `/direct/site/[siteId].json` の `sitePages` から「課題」ページの `page/[pageId]` URL を取得し、そこへ fetch することで得られる 302 リダイレクト先の URL から抽出している。

## Type of change

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## Levels of review
- [ ] Level1: 即ApproveしてOK
- [x] Level2: 軽く目を通して問題がなければApprove
- [ ] Level3: 実際にビルドして動作確認をしてほしい
