### PR TITLE
課題,クイズのfetch失敗時にPendingし続けるバグを修正, ターゲットの変更

### DIFF
--- a/src/features/api/fetch.ts
+++ b/src/features/api/fetch.ts
@@ -122,7 +122,7 @@ export const fetchQuiz = async (course: Course): Promise<Quiz> => {
 
         return new Quiz(course, quizEntries, true);
 
-    } catch(err) {
+    } catch (err) {
         console.error(err); // Error: Request failed: 404
         throw err; // rethrow
     }

--- a/src/features/api/fetch.ts
+++ b/src/features/api/fetch.ts
@@ -80,41 +80,50 @@ const fetchAssignmentPageURL = async (siteId: string): Promise<string | null> =>
 };
 
 /* Sakai APIから課題を取得する */
-export const fetchAssignment = (course: Course): Promise<Assignment> => {
+export const fetchAssignment = async (course: Course): Promise<Assignment> => {
     const queryURL = getBaseURL() + "/direct/assignment/site/" + course.id + ".json";
-    return new Promise((resolve, reject) => {
-        fetch(queryURL, { cache: "no-cache" })
-            .then(async (response) => {
-                if (response.ok) {
-                    const data = await response.json();
-                    const assignmentEntries = decodeAssignmentFromAPI(data);
-                    const assignmentPageURL = await fetchAssignmentPageURL(course.id);
-                    if (assignmentPageURL) {
-                        assignmentEntries.forEach(e => { e.assignmentPageURL = assignmentPageURL; });
-                    }
-                    resolve(new Assignment(course, assignmentEntries, false));
-                } else {
-                    reject(`Request failed: ${response.status}`);
-                }
-            })
-            .catch((err) => console.error(err)); // Error: Request failed: 404
-    });
+
+    try {
+        const response = await fetch(queryURL, { cache: "no-cache" });
+
+        if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const assignmentEntries = decodeAssignmentFromAPI(data);
+        const assignmentPageURL = await fetchAssignmentPageURL(course.id);
+
+        if (assignmentPageURL) {
+            assignmentEntries.forEach(e => { e.assignmentPageURL = assignmentPageURL; });
+        }
+
+        return new Assignment(course, assignmentEntries, false);
+
+    } catch (err) {
+        console.error(err); // Error: Request failed: 404
+        throw err; // rethrow
+    }
 };
 
 /* Sakai APIからクイズを取得する */
-export const fetchQuiz = (course: Course): Promise<Quiz> => {
+export const fetchQuiz = async (course: Course): Promise<Quiz> => {
     const queryURL = getBaseURL() + "/direct/sam_pub/context/" + course.id + ".json";
-    return new Promise((resolve, reject) => {
-        fetch(queryURL, { cache: "no-cache" })
-            .then(async (response) => {
-                if (response.ok) {
-                    const data = await response.json();
-                    const quizEntries = decodeQuizFromAPI(data);
-                    resolve(new Quiz(course, quizEntries, true));
-                } else {
-                    reject(`Request failed: ${response.status}`);
-                }
-            })
-            .catch((err) => console.error(err)); // Error: Request failed: 404
-    });
+
+    try {
+        const response = await fetch(queryURL, { cache: "no-cache" });
+
+        if (!response.ok) {
+            throw new Error(`Request failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const quizEntries = decodeQuizFromAPI(data);
+
+        return new Quiz(course, quizEntries, true);
+
+    } catch(err) {
+        console.error(err); // Error: Request failed: 404
+        throw err; // rethrow
+    }
 };

--- a/src/features/entity/assignment/getAssignment.ts
+++ b/src/features/entity/assignment/getAssignment.ts
@@ -16,7 +16,9 @@ export const getSakaiAssignments = async (hostname: string, courses: Array<Cours
     for (const assignment of result) {
         if (assignment.status === "fulfilled") assignments.push(assignment.value);
     }
-    await toStorage(hostname, AssignmentFetchTimeStorage, new Date().getTime() / 1000);
+    if (assignments.length > 0) {
+        await toStorage(hostname, AssignmentFetchTimeStorage, new Date().getTime() / 1000);
+    }
     return assignments;
 };
 

--- a/src/features/entity/assignment/getAssignment.ts
+++ b/src/features/entity/assignment/getAssignment.ts
@@ -12,7 +12,7 @@ export const getSakaiAssignments = async (hostname: string, courses: Array<Cours
     for (const course of courses) {
         pending.push(fetchAssignment(course));
     }
-    const result = await (Promise as any).allSettled(pending);
+    const result = await Promise.allSettled(pending);
     for (const assignment of result) {
         if (assignment.status === "fulfilled") assignments.push(assignment.value);
     }

--- a/src/features/entity/quiz/getQuiz.ts
+++ b/src/features/entity/quiz/getQuiz.ts
@@ -16,7 +16,9 @@ export const getSakaiQuizzes = async (hostname: string, courses: Array<Course>):
     for (const quiz of result) {
         if (quiz.status === "fulfilled") quizzes.push(quiz.value);
     }
-    await toStorage(hostname, QuizFetchTimeStorage, new Date().getTime() / 1000);
+    if (quizzes.length > 0) {
+        await toStorage(hostname, QuizFetchTimeStorage, new Date().getTime() / 1000);
+    }
     return quizzes;
 };
 

--- a/src/features/entity/quiz/getQuiz.ts
+++ b/src/features/entity/quiz/getQuiz.ts
@@ -12,7 +12,7 @@ export const getSakaiQuizzes = async (hostname: string, courses: Array<Course>):
     for (const course of courses) {
         pending.push(fetchQuiz(course));
     }
-    const result = await (Promise as any).allSettled(pending);
+    const result = await Promise.allSettled(pending);
     for (const quiz of result) {
         if (quiz.status === "fulfilled") quizzes.push(quiz.value);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "lib": ["ES2020", "DOM"],                 /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -21,7 +21,7 @@
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */


### PR DESCRIPTION
# 課題,クイズのfetch失敗時にPendingし続けるバグを修正、ターゲットの変更

## Description
課題やクイズのfetchに失敗した時に、`catch`でエラーをログに表示していたが、その後に`resolve`や`reject`が為されておらず、pending状態のままになっていたので、例外を再スローするようにし、またasync/await構文を用いることでバグを発生しづらくした。

また`fetchAssignment`, `fetchQuiz`呼び出し側のコードのrefactoringも行った

またtargetをES5からES2015以上に変更した

## Type of change

- [x] バグ修正
- [ ] 新機能
- [ ] その他

## Levels of review
- [ ] Level1: 即ApproveしてOK
- [ ] Level2: 軽く目を通して問題がなければApprove
- [x] Level3: 実際にビルドして動作確認をしてほしい